### PR TITLE
Added Marathon framework

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -19,6 +19,12 @@ chronos:
     - "14400:4400"
   links:
     - zookeeper:zookeeper
+marathon:
+  build: mesos-marathon
+  ports:
+    - "18080:8080"
+  links:
+    - zookeeper:zookeeper
 nimbus:
   build: mesos-storm
   ports:

--- a/mesos-marathon/Dockerfile
+++ b/mesos-marathon/Dockerfile
@@ -1,0 +1,8 @@
+FROM mesos
+MAINTAINER Mark O'Connor <mark@myspotontheweb.com>
+
+RUN echo "zk://zookeeper:2181/mesos" > /etc/mesos/zk
+
+EXPOSE 8080
+
+CMD ["marathon"]


### PR DESCRIPTION
My first contribution to the cause.

Chronos still works for me...

MArk

PS

```
         Name                        Command               State                         Ports                       
 --------------------------------------------------------------------------------------------------------------------
dockermesos_zookeeper_1   /usr/share/zookeeper/bin/z ...   Up      49181->2181/tcp                                   
dockermesos_master_1      --zk=zk://zookeeper:2181/m ...   Up      15050->5050/tcp                                   
dockermesos_nimbus_1      /storm-mesos-0.9/bin/storm ...   Up      49773->3773/tcp, 49772->3772/tcp, 49627->6627/tcp 
dockermesos_stormui_1     /storm-mesos-0.9/bin/storm ui    Up      49080->8080/tcp                                   
dockermesos_chronos_1     chronos                          Up      14400->4400/tcp                                   
dockermesos_slave_1       --master=zk://zookeeper:21 ...   Up                                                        
dockermesos_marathon_1    marathon                         Up      18080->8080/tcp          
```
