### PR TITLE
Install unzip so that mesos-fetcher can extract archives.

### DIFF
--- a/mesos/Dockerfile
+++ b/mesos/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER yaronr
 RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
 RUN apt-get -y update
-RUN apt-get -y install wget supervisor python mesos marathon chronos
+RUN apt-get -y install wget unzip supervisor python mesos marathon chronos


### PR DESCRIPTION
Thanks for creating this project. I was just trying out the example on https://mesosphere.io/learn/run-play-on-mesos/. This failed because mesos-fetcher could not unzip http://downloads.mesosphere.io/tutorials/PlayHello.zip. Installing unzip fixes this problem.
